### PR TITLE
FIX: trying to read directories as files

### DIFF
--- a/indexer_v1.go
+++ b/indexer_v1.go
@@ -155,7 +155,9 @@ func listFiles(folderPath string) ([]string, error) {
 
 	var fileNames []string
 	for _, file := range files {
-		fileNames = append(fileNames, file.Name())
+		if !file.IsDir() {
+			fileNames = append(fileNames, file.Name())
+		}
 	}
 	return fileNames, nil
 }


### PR DESCRIPTION
Fixed the issue with the list files function missing a proper directory filter.